### PR TITLE
Upgrades to bullseye to fix ruby issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
   build_push_to_dockerhub:
     strategy:
       matrix:
-        base_container: ["php:7.4-buster", "php:8.0-buster", "php:8.1-buster"]
+        base_container: ["php:7.4-bullseye", "php:8.0-bullseye", "php:8.1-bullseye"]
     runs-on: ubuntu-20.04
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ RUN apt-get update && \
       default-mysql-client \
       openssh-client \
       openssl \
-      python-pip \
       python3-pip \
       rsync \
       ruby \
@@ -110,13 +109,14 @@ COPY .bowerrc /root/.bowerrc
 
 ## Compass ##
 
-RUN gem update --system && \
-    gem install compass
+RUN gem install compass
 
 ## Ansible, awscli, other Python tools ##
 
 COPY requirements.txt /tmp/requirements.txt 
-RUN pip3 install --upgrade pip && pip3 --no-cache-dir install -r /tmp/requirements.txt
+RUN python3 -m pip -V && \
+    python3 -m pip install -r /tmp/requirements.txt
+#RUN pip3 install --upgrade pip && pip3 --no-cache-dir install -r /tmp/requirements.txt
 
 ## Composer ##
 ARG COMPOSER_VERSION 1
@@ -130,11 +130,11 @@ RUN /tmp/install-composer.sh && \
 
 ## Docker ##
 
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/debian \
-      $(lsb_release -cs) \
-      stable" && \
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
     apt-get install -y docker-ce-cli && \
     apt-get autoremove -y && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ yq
 python-gitlab
 awesome-codename
 cryptography
-ansible==2.11.6
+ansible-core==2.11.6
 dnspython


### PR DESCRIPTION
upgrades php base image to debian 11 ( bullseye ) to fix dependences. Buster is considered "oldstable" and not actively maintained. 