### PR TITLE
Run php linter in parallel

### DIFF
--- a/scripts/php-syntax
+++ b/scripts/php-syntax
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 php -l
+find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P $(nproc) php -l


### PR DESCRIPTION
### Description of the Change

This PR changes the call to `php -l` so it can check more files in parallel. The change was based on this [blog post](https://www.stefaanlippens.net/php-lint-multiple-files-parallel/) and was tested in a local container.


### Changelog Entry
> Changed - `php-syntax` to check files in parallel


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
