### PR TITLE
19362336 | feat: added in php-8.2-bullseye container (INTERIM)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
   build_push_to_dockerhub:
     strategy:
       matrix:
-        base_container: ["php:7.4-bullseye", "php:8.0-bullseye", "php:8.1-bullseye"]
+        base_container: ["php:7.4-bullseye", "php:8.0-bullseye", "php:8.1-bullseye", "php:8.2-bullseye"]
     runs-on: ubuntu-20.04
 
     steps:
@@ -22,6 +22,8 @@ jobs:
 
       # 7.4 is the current "latest" default version and gets this extra tag
       # upon EOL, this should move to 8.0
+      # Oct 10, 2023 - NOTE: https://tenup.teamwork.com/app/tasks/19362336 
+      # 7.4 has already reached EoL, we can consider 8.0 as default version now
       - name: Set PHP 7.4 settings
         if: ${{ matrix.base_container == 'php:7.4-bullseye' }}
         run: |
@@ -38,6 +40,12 @@ jobs:
         if: ${{ matrix.base_container == 'php:8.1-bullseye' }}
         run: |
           echo "BUILD_TAGS=10up/wordpress-ci:php-8.1" >> $GITHUB_ENV
+          echo "COMPOSER_VERSION=2" >> $GITHUB_ENV
+      
+      - name: Set PHP 8.2 settings
+        if: ${{ matrix.base_container == 'php:8.2-bullseye' }}
+        run: |
+          echo "BUILD_TAGS=10up/wordpress-ci:php-8.2" >> $GITHUB_ENV
           echo "COMPOSER_VERSION=2" >> $GITHUB_ENV
 
       ## GitHub Action validation testing before starting workflow ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && \
       libxext6 \
       libxfixes3 \
       libxi6 \
+      libxml2-dev \
       libxrandr2 \
       libxrender1 \
       libxss1 \
@@ -93,7 +94,7 @@ RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" && \
     echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
 
 ## PHP extensions ##
-RUN docker-php-ext-install zip pdo pdo_mysql gd bcmath intl sockets mysqli exif
+RUN docker-php-ext-install zip pdo pdo_mysql gd bcmath intl sockets mysqli exif soap
 
 #### Specific to building / deploying ####
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,10 @@ ENV NVM_DIR /tmp/.nvm
 RUN mkdir ${NVM_DIR}
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 
+# Workaround - Cypress installation
+ENV CYPRESS_CACHE_FOLDER /tmp/cypress/cache
+RUN mkdir -p ${CYPRESS_CACHE_FOLDER} && chmod 777 ${CYPRESS_CACHE_FOLDER}
+
 COPY build/install-node.sh /tmp/install-node.sh
 RUN chmod +x /tmp/install-node.sh && /tmp/install-node.sh
 COPY .bowerrc /root/.bowerrc

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - lighthouse
 - serverless
 - firebase-tools
+- cypress
 
 Node and npm are managed by the `build/install-node.sh` script.
 

--- a/build/install-node.sh
+++ b/build/install-node.sh
@@ -24,7 +24,8 @@ npm install -g \
     yarn \
     lighthouse \
     serverless \
-    firebase-tools
+    firebase-tools \
+    cypress
 
 npm cache clean --force
 

--- a/build/install-node.sh
+++ b/build/install-node.sh
@@ -11,7 +11,8 @@
 # catch Errors
 set -euo pipefail
 
-NODE_VERSION="16"
+# Updated install-node.sh due to the following issue, fixed in a more specific LTS version of 16 (v16.20.2 - gallium):
+NODE_VERSION="v16.20.2"
 
 # set up nvm in this script
 . "$NVM_DIR/nvm.sh"

--- a/build/install-node.sh
+++ b/build/install-node.sh
@@ -21,6 +21,7 @@ echo "Building node environment for version ${NODE_VERSION}"
 
 nvm install "${NODE_VERSION}"
 
+# Cypress version added since latest supports v18.x and above. Setting Cypress version to 13.1.0 according to cypress changelog for supporting node v16.x releases.
 npm install -g \
     grunt-cli \
     gulp-cli \
@@ -29,7 +30,7 @@ npm install -g \
     lighthouse \
     serverless \
     firebase-tools \
-    cypress
+    cypress@~13.1
 
 npm cache clean --force
 

--- a/build/install-node.sh
+++ b/build/install-node.sh
@@ -8,6 +8,9 @@
 
 # TODO: NODE_VERSION variable could be centralized in the Dockerfile for quicker management
 
+# catch Errors
+set -euo pipefail
+
 NODE_VERSION="16"
 
 # set up nvm in this script


### PR DESCRIPTION
### Description of the Change
Added in support for PHP 8.2 containers in CI and fixed relative packages during container build.

#### My WSL Distro
```
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.2 LTS
Release:        22.04
Codename:       jammy
```

#### _**Changes**_
- Added `php:8.2-bullseye` to `base_containers` for build job, `build_push_to_dockerhub`.
- Added in a step for configuring php 8.2 settings:
```yaml
  - name: Set PHP 8.2 settings
        if: ${{ matrix.base_container == 'php:8.2-bullseye' }}
        run: |
          echo "BUILD_TAGS=10up/wordpress-ci:php-8.2" >> $GITHUB_ENV
          echo "COMPOSER_VERSION=2" >> $GITHUB_ENV
```
- Updated `install-node.sh` due to the following issue, fixed in a more specific LTS version of 16 (v16.20.2 - gallium):
![image](https://github.com/10up/wordpress-ci-container/assets/43408958/11762026-4efd-43e5-8f07-0f7f1b2d630c)

- Cypress version added since latest supports `v18.x and above`. Setting Cypress version to _**~13.1**_ according to [cypress changelog](https://docs.cypress.io/guides/references/changelog#13-1-0) for supporting node `v16.x` releases, open for patch updates.
_**REF**_:
![image](https://github.com/10up/wordpress-ci-container/assets/43408958/0d624f58-783d-44cb-8976-8eee090782d7)





#### _**Commands used for tests:**_
1. Building image:
```bash
docker build --build-arg PHP_IMG=php:8.2-bullseye .
```
We have a successful build:
![image](https://github.com/10up/wordpress-ci-container/assets/43408958/1339a57c-8f45-4d19-92cc-9ff8f39da5da)
2. Creating a container:
```bash
# Image was created without name, so I passed the image id manually
docker run -it --name=wp-ci-container-test 42e301a7fcce2a1b9b50c0227f0fc4aaae7ce107051151d428b5d1a53f542b58
```
❗ The container exists without any issues.
![image](https://github.com/10up/wordpress-ci-container/assets/43408958/7dd67c4b-6a4e-48b2-9c0d-b493c6a401ac)

#### _**Notes:**_
1. Internal projects such as _**Ci-Library**_ and _**Ansible Playbooks**_ would need to be updated to utilize the updated PHP image.

#### _**Issue Reference**_
https://tenup.teamwork.com/app/tasks/19362336
### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Added - `php-8.2-bullseye` support to build containers for php 8.2
> Fixed - `node-version` installed via nvm from `16` to `v16.20.2`
> Fixed - `npm:cypress` to version `~13.1` to match with gallium (node `v16.x-lts`) 


### Credits
Props @syedahmedhaidershah @pablojmarti


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
