### PR TITLE
feat: multi-threaded php-syntax check

### DIFF
--- a/scripts/php-syntax
+++ b/scripts/php-syntax
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # The -P10 option specifies the number of parallel processes (In constrainted CPUs will take approx time for 1 available cpu)
-find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l
+find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l 1>/dev/null

--- a/scripts/php-syntax
+++ b/scripts/php-syntax
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 php -l
+# The -P10 option specifies the number of parallel processes (In constrainted CPUs will take approx time for 1 available cpu)
+find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
- Updated [php-syntax check / lint script](https://github.com/10up/wordpress-ci-container/blob/feature/ci-container-performance-enhancement/scripts/php-syntax) to test in parallel using upto 10 processes.

### How to test the Change
You can execute
```bash
time find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 php -l
```
and compare it with
```bash
find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l
```
The fastest speedup I got locally in a WSL2 container was from
`real    0m25.032s`
to
`real    0m5.016s`.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Added `-P10` flag to php-syntax checker to use upto 10 processes for a directory object.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @syedahmedhaidershah @pablojmarti


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
