### PR TITLE
update ansible to 2.11.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update && \
       default-mysql-client \
       openssh-client \
       openssl \
+      python3 \
       python3-pip \
       rsync \
       ruby \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,9 @@ yq
 python-gitlab
 awesome-codename
 cryptography
+<<<<<<< Updated upstream
 ansible-core==2.11.6
+=======
+ansible-core==2.11.12
+>>>>>>> Stashed changes
 dnspython

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,5 @@ yq
 python-gitlab
 awesome-codename
 cryptography
-<<<<<<< Updated upstream
-ansible-core==2.11.6
-=======
 ansible-core==2.11.12
->>>>>>> Stashed changes
 dnspython


### PR DESCRIPTION
### Description of the Change
Update ansible core to the latest version of `2.11`

### How to test the Change
1. Checkout branch locally
2. build container (ex: `docker build --build-arg PHP_IMG=php:8.2-buster .`)
3. Test ansible 


