### PR TITLE
fix: enhanced bool flag checking from CI env vars for php-syntax verbose

### DIFF
--- a/scripts/php-syntax
+++ b/scripts/php-syntax
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # Checking if the IS_DEBUG_ENABLED flag is put in the CI environment
-IS_DEBUG_ENABLED=$( [ -n "$IS_DEBUG_ENABLED" ] && echo "$IS_DEBUG_ENABLED" || echo "" )
-
-if [[ -n "$IS_DEBUG_ENABLED" ]]; then
+if [ "${IS_DEBUG_ENABLED:-false}" = "true" ]; then
     # The -P10 option specifies the number of parallel processes (In constrainted CPUs will take approx time for 1 available cpu)
     # This will output stdout logs
     find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l
+    exit 1
 else
     # The -P10 option specifies the number of parallel processes (In constrainted CPUs will take approx time for 1 available cpu)
     # This will NOT output stdout logs
     find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l 1>/dev/null
+    exit 1
 fi

--- a/scripts/php-syntax
+++ b/scripts/php-syntax
@@ -5,10 +5,8 @@ if [ "${IS_DEBUG_ENABLED:-false}" = "true" ]; then
     # The -P10 option specifies the number of parallel processes (In constrainted CPUs will take approx time for 1 available cpu)
     # This will output stdout logs
     find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l
-    exit 1
 else
     # The -P10 option specifies the number of parallel processes (In constrainted CPUs will take approx time for 1 available cpu)
     # This will NOT output stdout logs
     find . -type f -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P10 php -l 1>/dev/null
-    exit 1
 fi


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
If checks for unbound variables is set via `set -u`, the `IS_DEBUG_ENABLED` check for the verbose flag will throw an exception.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Utilize the container in your CI, with `set -u` explicitly enabled. The `php-syntax` script will execute correctly.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Unhandled unbound variable exception


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @syedahmedhaidershah , @dustinrue , @pablojmarti 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
